### PR TITLE
Fix Flashscore markup parsing and add sample parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "fscore-follow",
+  "version": "1.0.0",
+  "description": "Kişisel, sessiz bildirimli ve global toolbar’lı Flashscore maç takip uzantısı. DOM Modu önceliklidir; FS sekmesi yoksa yedek Polling devreye girer.",
+  "scripts": {
+    "parse-sample": "node scripts/parse-sample.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "jsdom": "^26.1.0"
+  }
+}

--- a/scripts/parse-sample.js
+++ b/scripts/parse-sample.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const { JSDOM } = require('jsdom');
+
+// Stub chrome runtime for utils
+global.chrome = { runtime: {} };
+
+// Load HTML sample
+const html = fs.readFileSync('html_ornegi.html', 'utf8');
+const dom = new JSDOM(html);
+
+global.window = dom.window;
+global.document = dom.window.document;
+
+// Load extension utilities and selectors
+require('../src/lib/utils.js');
+// expose FSUtils globally for selectors
+global.FSUtils = window.FSUtils;
+require('../src/lib/selectors.js');
+
+const { S, extractMatchId, extractTeams, extractStage, extractScore, extractUrl } = window.FSSelectors;
+
+// Extract first 5 match rows as a demo
+const rows = Array.from(document.querySelectorAll(S.ROW)).slice(0, 5);
+const matches = rows.map(row => {
+  const id = extractMatchId(row);
+  const teams = extractTeams(row);
+  const score = extractScore(row);
+  const stage = extractStage(row);
+  const url = extractUrl(row);
+  return { id, ...teams, score, stage, url };
+});
+
+console.log(JSON.stringify(matches, null, 2));

--- a/src/lib/selectors.js
+++ b/src/lib/selectors.js
@@ -7,8 +7,8 @@
     MORE: 'div.event__more, div.event__more--static',
   SCORE: 'div.event__scores, div.event__score, .event__part--home, .event__part--away, [data-testid="wcl-matchRowScore"]',
   TIME: 'div.event__time, div.event__stage, .event__stage--block, [data-testid="wcl-matchRowTime"], [data-testid="wcl-matchRowStatus"]',
-    HOME: 'div.event__participant--home, div.event__participant:nth-of-type(1)',
-    AWAY: 'div.event__participant--away, div.event__participant:nth-of-type(2)',
+    HOME: 'div.event__participant--home, div.event__participant:nth-of-type(1), [data-testid="wcl-matchRow-participant"].event__homeParticipant',
+    AWAY: 'div.event__participant--away, div.event__participant:nth-of-type(2), [data-testid="wcl-matchRow-participant"].event__awayParticipant',
     ROWLINK: 'a.eventRowLink[href*="/match/"]'
   };
 
@@ -28,7 +28,7 @@
     let home = FSUtils.getText(row.querySelector(S.HOME));
     let away = FSUtils.getText(row.querySelector(S.AWAY));
     if (!home || !away) {
-      const parts = row.querySelectorAll('div.event__participant');
+      const parts = row.querySelectorAll('div.event__participant, [data-testid="wcl-matchRow-participant"]');
       if (parts.length >= 2) {
         home = home || FSUtils.getText(parts[0]);
         away = away || FSUtils.getText(parts[1]);
@@ -50,7 +50,14 @@
     let t = FSUtils.getText(row.querySelector(S.SCORE));
     let s = FSUtils.regexScore(t);
     if (!s) {
-      // Bazı varyantlarda home ve away part ayrı olabilir.
+      const scoreEls = row.querySelectorAll('[data-testid="wcl-matchRowScore"]');
+      if (scoreEls.length >= 2) {
+        const home = FSUtils.getText(scoreEls[0]);
+        const away = FSUtils.getText(scoreEls[1]);
+        if (home && away && /\d/.test(home) && /\d/.test(away)) s = `${home}-${away}`.replace(/\s+/g, '');
+      }
+    }
+    if (!s) {
       const home = FSUtils.getText(row.querySelector('.event__part--home'));
       const away = FSUtils.getText(row.querySelector('.event__part--away'));
       if (home && away && /\d/.test(home) && /\d/.test(away)) s = `${home}-${away}`.replace(/\s+/g, '');


### PR DESCRIPTION
## Summary
- adapt selectors to new Flashscore DOM for teams and scores
- add jsdom-based parser script and package.json

## Testing
- `npm run parse-sample`


------
https://chatgpt.com/codex/tasks/task_e_689d335e60e0832fa99859417957edbc