### PR TITLE
Refactor parsing utilities and add CLI parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,9 @@ Kişisel, sessiz bildirimli ve global toolbar’lı Flashscore maç takip uzant�
 4. FS sekmelerini kapatın; yaklaşık 1 dakika içinde polling etkin olup skor değişimi yakalayabilmeli.
 5. Gol olduğunda toolbar satırı kısa süre yeşil highlight olur ve sessiz bildirim çıkar.
 
+## CLI Parser
+- `npm run parse-sample`: `html_ornegi.html` üzerindeki ilk 5 maçı JSON olarak döndürür; çıktıda `title`, `sport` ve varsa son olay (`event`) alanları bulunur.
+- `npm run parse <dosya-yolu veya URL> [limit]`: Belirtilen kaynaktan maçları çekip JSON olarak yazar.
+
 ## Yasal Not
 Bu uzantı yalnızca kullanıcının gezdiği sayfanın görünür DOM’unu ve takip edilen maçların detay sayfası HTML’ini makul hız/limitlerde işler. Herhangi bir resmi API kullanılmaz.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "fscore-follow",
+  "version": "1.0.0",
+  "description": "Kişisel, sessiz bildirimli ve global toolbar’lı Flashscore maç takip uzantısı. DOM Modu önceliklidir; FS sekmesi yoksa yedek Polling devreye girer.",
+  "scripts": {
+    "parse-sample": "node scripts/parse-sample.js",
+    "parse": "node scripts/parse.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "jsdom": "^26.1.0"
+  }
+}

--- a/scripts/parse-sample.js
+++ b/scripts/parse-sample.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const { parseMatches } = require('../src/lib/parser.js');
+
+// Demo: parse bundled HTML sample and print first 5 matches.
+const html = fs.readFileSync('html_ornegi.html', 'utf8');
+const matches = parseMatches(html, { limit: 5, base: 'https://www.flashscore.com' });
+console.log(JSON.stringify(matches, null, 2));
+

--- a/scripts/parse.js
+++ b/scripts/parse.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const { parseMatches } = require('../src/lib/parser.js');
+
+async function main() {
+  const input = process.argv[2];
+  const limit = parseInt(process.argv[3] || '', 10) || undefined;
+  if (!input) {
+    console.error('Usage: node scripts/parse.js <url-or-file> [limit]');
+    process.exit(1);
+  }
+  let html;
+  if (/^https?:/i.test(input)) {
+    const res = await fetch(input);
+    html = await res.text();
+  } else {
+    html = fs.readFileSync(input, 'utf8');
+  }
+  const matches = parseMatches(html, { limit, base: input });
+  console.log(JSON.stringify(matches, null, 2));
+}
+
+main();
+

--- a/src/lib/parser.js
+++ b/src/lib/parser.js
@@ -1,0 +1,27 @@
+const { JSDOM } = require('jsdom');
+const { S, extractMatchId, extractTeams, extractStage, extractScore, extractUrl, buildTitle, detectSport, extractEventHint } = require('./selectors.js');
+
+/**
+ * Parse Flashscore match rows from given HTML.
+ * @param {string} html - Flashscore sayfa HTML'i
+ * @param {{limit?:number, base?:string}} [opts]
+ */
+function parseMatches(html, opts = {}) {
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  const rows = Array.from(doc.querySelectorAll(S.ROW)).slice(0, opts.limit || undefined);
+    return rows.map(row => {
+      const id = extractMatchId(row);
+      const teams = extractTeams(row);
+      const score = extractScore(row);
+      const stage = extractStage(row);
+      const url = extractUrl(row, opts.base);
+      const title = buildTitle(teams);
+      const sport = detectSport(row);
+      const event = extractEventHint(row);
+      return { id, ...teams, score, stage, url, title, sport, ...(event ? { event } : {}) };
+    });
+}
+
+module.exports = { parseMatches };
+

--- a/src/lib/selectors.js
+++ b/src/lib/selectors.js
@@ -1,83 +1,117 @@
 // Flashscore seçiciler ve veri çıkarımı; çoklu selector + fallback.
-// JSDoc ekli; başlık stabil "Team A — Team B".
+// Hem tarayıcı hem Node ortamında kullanılabilir.
 
-(function () {
-  const S = {
+function factory(FSUtils) {
+const S = {
   ROW: 'div.event__match, div.event__match--live, div.event__match--scheduled, div.event__match--twoLine, div.event__match--withRowLink',
-    MORE: 'div.event__more, div.event__more--static',
+  MORE: 'div.event__more, div.event__more--static',
   SCORE: 'div.event__scores, div.event__score, .event__part--home, .event__part--away, [data-testid="wcl-matchRowScore"]',
   TIME: 'div.event__time, div.event__stage, .event__stage--block, [data-testid="wcl-matchRowTime"], [data-testid="wcl-matchRowStatus"]',
-    HOME: 'div.event__participant--home, div.event__participant:nth-of-type(1)',
-    AWAY: 'div.event__participant--away, div.event__participant:nth-of-type(2)',
-    ROWLINK: 'a.eventRowLink[href*="/match/"]'
-  };
+  HOME: 'div.event__participant--home, div.event__participant:nth-of-type(1), [data-testid="wcl-matchRow-participant"].event__homeParticipant',
+  AWAY: 'div.event__participant--away, div.event__participant:nth-of-type(2), [data-testid="wcl-matchRow-participant"].event__awayParticipant',
+  ROWLINK: 'a.eventRowLink[href*="/match/"]'
+};
 
-  /** @param {Element} row */
-  function extractMatchId(row) {
-    if (row.id && row.id.startsWith('g_')) return row.id;
-    const a = row.querySelector(S.ROWLINK);
-    if (a) {
-      const href = a.getAttribute('href') || '';
-      const m = href.match(/\/match\/([A-Za-z0-9]+)\//);
-      if (m) return m[1];
-    }
-    return FSUtils.hash((row.textContent || '').slice(0, 200));
+/** @param {Element} row */
+function extractMatchId(row) {
+  if (row.id && row.id.startsWith('g_')) return row.id;
+  const a = row.querySelector(S.ROWLINK);
+  if (a) {
+    const href = a.getAttribute('href') || '';
+    const m = href.match(/\/match\/([A-Za-z0-9]+)\//);
+    if (m) return m[1];
   }
-  /** @param {Element} row */
-  function extractTeams(row) {
-    let home = FSUtils.getText(row.querySelector(S.HOME));
-    let away = FSUtils.getText(row.querySelector(S.AWAY));
-    if (!home || !away) {
-      const parts = row.querySelectorAll('div.event__participant');
-      if (parts.length >= 2) {
-        home = home || FSUtils.getText(parts[0]);
-        away = away || FSUtils.getText(parts[1]);
-      }
+  return FSUtils.hash((row.textContent || '').slice(0, 200));
+}
+
+function cleanParticipantText(el) {
+  if (!el) return '';
+  const clone = el.cloneNode(true);
+  clone.querySelectorAll('.event__important, [data-testid="wcl-matchRowHistory"], [data-testid="wcl-participantMessage"]').forEach(n => n.remove());
+  return FSUtils.getText(clone);
+}
+
+/** @param {Element} row */
+function extractTeams(row) {
+  let home = cleanParticipantText(row.querySelector(S.HOME));
+  let away = cleanParticipantText(row.querySelector(S.AWAY));
+  if (!home || !away) {
+    const parts = row.querySelectorAll('div.event__participant, [data-testid="wcl-matchRow-participant"]');
+    if (parts.length >= 2) {
+      home = home || cleanParticipantText(parts[0]);
+      away = away || cleanParticipantText(parts[1]);
     }
-    home = (home || '').replace(/\s+/g, ' ').trim();
-    away = (away || '').replace(/\s+/g, ' ').trim();
-    return { home, away };
   }
-  /** @param {Element} row */
-  function extractStage(row) {
+  home = (home || '').replace(/\s+/g, ' ').trim();
+  away = (away || '').replace(/\s+/g, ' ').trim();
+  return { home, away };
+}
+
+/** @param {Element} row */
+function extractStage(row) {
   const t = FSUtils.getText(row.querySelector(S.TIME));
   // HT/FT/1st/2nd gibi ibareler öncelikli, değilse tüm metni döndür.
   const tok = FSUtils.regexStage(t);
   return tok || t || '';
-  }
-  /** @param {Element} row */
-  function extractScore(row) {
-    let t = FSUtils.getText(row.querySelector(S.SCORE));
-    let s = FSUtils.regexScore(t);
-    if (!s) {
-      // Bazı varyantlarda home ve away part ayrı olabilir.
-      const home = FSUtils.getText(row.querySelector('.event__part--home'));
-      const away = FSUtils.getText(row.querySelector('.event__part--away'));
+}
+
+/** @param {Element} row */
+function extractScore(row) {
+  let t = FSUtils.getText(row.querySelector(S.SCORE));
+  let s = FSUtils.regexScore(t);
+  if (!s) {
+    const scoreEls = row.querySelectorAll('[data-testid="wcl-matchRowScore"]');
+    if (scoreEls.length >= 2) {
+      const home = FSUtils.getText(scoreEls[0]);
+      const away = FSUtils.getText(scoreEls[1]);
       if (home && away && /\d/.test(home) && /\d/.test(away)) s = `${home}-${away}`.replace(/\s+/g, '');
     }
-    return s;
   }
-  /** @param {Element} row */
-  function extractUrl(row) {
-    const a = row.querySelector(S.ROWLINK);
-    const href = a?.getAttribute('href') || '';
-    if (!href) return '';
-    try { return new URL(href, location.origin).href; } catch { return href; }
+  if (!s) {
+    const home = FSUtils.getText(row.querySelector('.event__part--home'));
+    const away = FSUtils.getText(row.querySelector('.event__part--away'));
+    if (home && away && /\d/.test(home) && /\d/.test(away)) s = `${home}-${away}`.replace(/\s+/g, '');
   }
-  function buildTitle(teams) {
-    if (!teams.home && !teams.away) return 'Maç';
-    return `${teams.home || 'Home'} — ${teams.away || 'Away'}`;
-  }
-  function detectSport() { return 'football'; }
+  return s;
+}
 
-  /** Satır metninden basit olay sinyali (GOAL/KIRMIZI/SARI vb) çıkarır. */
-  function extractEventHint(row) {
-    const txt = (row.textContent || '').toUpperCase();
-    if (txt.includes('GOAL')) return { type: 'goal', text: 'Gol' };
-    if (txt.includes('RED CARD')) return { type: 'red', text: 'Kırmızı Kart' };
-    if (txt.includes('YELLOW CARD')) return { type: 'yellow', text: 'Sarı Kart' };
-    return undefined;
+/** @param {Element} row */
+function extractUrl(row, base) {
+  const a = row.querySelector(S.ROWLINK);
+  const href = a?.getAttribute('href') || '';
+  if (!href) return '';
+  try {
+    const origin = base || (typeof location !== 'undefined' ? location.origin : '');
+    return new URL(href, origin).href;
+  } catch {
+    return href;
   }
+}
 
-  window.FSSelectors = { S, extractMatchId, extractTeams, extractStage, extractScore, extractUrl, buildTitle, detectSport, extractEventHint };
-})();
+function buildTitle(teams) {
+  if (!teams.home && !teams.away) return 'Maç';
+  return `${teams.home || 'Home'} — ${teams.away || 'Away'}`;
+}
+
+function detectSport() { return 'football'; }
+
+/** Satır metninden basit olay sinyali (GOAL/KIRMIZI/SARI vb) çıkarır. */
+function extractEventHint(row) {
+  const txt = (row.textContent || '').toUpperCase();
+  if (txt.includes('GOAL')) return { type: 'goal', text: 'Gol' };
+  if (txt.includes('RED CARD')) return { type: 'red', text: 'Kırmızı Kart' };
+  if (txt.includes('YELLOW CARD')) return { type: 'yellow', text: 'Sarı Kart' };
+  return undefined;
+}
+
+return { S, extractMatchId, extractTeams, extractStage, extractScore, extractUrl, buildTitle, detectSport, extractEventHint };
+}
+
+(function (root) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory(require('./utils.js'));
+  } else {
+    root.FSSelectors = factory(root.FSUtils);
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -2,12 +2,11 @@
 // throttle, safeSendMessage, hash, query, text, score regex, visibility lifecycle.
 
 /* global chrome */
-(function () {
-  const SCORE_RE = /(\d+)\s*[-:]\s*(\d+)/;
-  // Dakika sembolü farklı Unicode olabilir (’ ′ '), ayrıca farklı dilde LIVE/canlı ibareleri
-  const MIN_STAGE_RE = /\b(FT|HT|[0-9]{1,3}(?:’|′|')|1st|2nd|ET|LIVE|CANLI|PEN)\b/i;
+const SCORE_RE = /(\d+)\s*[-:]\s*(\d+)/;
+// Dakika sembolü farklı Unicode olabilir (’ ′ '), ayrıca farklı dilde LIVE/canlı ibareleri
+const MIN_STAGE_RE = /\b(FT|HT|[0-9]{1,3}(?:’|′|')|1st|2nd|ET|LIVE|CANLI|PEN)\b/i;
 
-  const FSUtils = {
+const buildFSUtils = () => ({
     throttle(fn, wait) {
       let t = 0, timer = null, lastArgs = null;
       return (...args) => {
@@ -67,7 +66,10 @@
       }, { passive: true });
       window.addEventListener('pagehide', () => {/* no-op */}, { passive: true });
     }
-  };
+  });
 
-  window.FSUtils = FSUtils;
-})();
+(function (root) {
+  const FSUtils = buildFSUtils();
+  if (typeof module === 'object' && module.exports) module.exports = FSUtils;
+  else root.FSUtils = FSUtils;
+})(typeof globalThis !== 'undefined' ? globalThis : this);


### PR DESCRIPTION
## Summary
- convert utility and selector scripts to dual browser/Node modules
- add reusable HTML parser and generic CLI script
- document new parser usage in README
- include event metadata and cleaned team names in parser output
- expose helpers via UMD wrappers for reliable global access

## Testing
- `npm run parse-sample`
- `node scripts/parse.js html_ornegi.html 3`


------
https://chatgpt.com/codex/tasks/task_e_689d335e60e0832fa99859417957edbc